### PR TITLE
add BROWSER env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,12 @@ $ echo "cat pictures" | bang -url gi -
 https://www.google.com/search?tbm=isch&q=cat+pictures
 ```
 
+Supports launching custom programs as subshells using the `BROWSER` environment variable:
+
+```console
+$ export BROWSER="chromium-browser --incognito"
+$ bang gi cat pictures
+# open the search for cat pictures in an incognito Chromium session
+```
+
 [ddg-bangs]: https://duckduckgo.com/bang


### PR DESCRIPTION
Adds docs to the README about support for the `BROWSER` environment variable.