### PR TITLE
docs and usage; stdin improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ The CLI looks for a config file named `bangs.(json|yml|yaml|toml|hcl)` in the fo
 
 - `description` `(string: <req>)` is a friendly description for the Bang.
 - `escape_method` `(int: 0)` defines how the query is escaped prior to it being substituted within the Bang's `format`:
-  - `0` - Escapes with `url.QueryEscape`: `cat pictures` &Rarr; `cat+pictures`. This is the default method.
-  - `1` - Pass-through without escaping: `cat pictures` &Rarr; `cat pictures`
-  - `2` - Escapes with `url.PathEscape`: `cat pictures` &Rarr; `cat%20pictures`
+  - `0` - Escapes with `url.QueryEscape`: `cat pictures` &rArr; `cat+pictures`. This is the default method.
+  - `1` - Pass-through without escaping: `cat pictures` &rArr; `cat pictures`
+  - `2` - Escapes with `url.PathEscape`: `cat pictures` &rArr; `cat%20pictures`
 - `format` `(string: <req>)` defines the template used to create the Bang's resulting query string. Use `{{{s}}}` to denote where the query should be substituted.
 
 See the [`bang.proto`](bang.proto) file for the Bang object format.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,15 @@ The system's URL opener will be used by default, but if set, the `BROWSER` envir
 
 ## Config
 
-The CLI looks for a config file named `bangs.(json|yml|yaml|toml|hcl)` in the following locations, in order: `~/.config/bang/`, `~/.config/`, `.` (current directory). Each key of the config file should be the unique `name` of a Bang, with the following properties:
+The CLI looks for a config file named `bangs.(json|yml|yaml|toml|hcl)` in the following locations, in order:
+
+```
+~/.config/bang/
+~/.config/
+./ (current directory)
+```
+
+Each key of the config file should be the unique `name` of a Bang, with the following properties:
 
 - `description` `(string: <req>)` is a friendly description for the Bang.
 - `escape_method` `(int: 0)` defines how the query is escaped prior to it being substituted within the Bang's `format`:
@@ -30,6 +38,16 @@ The CLI looks for a config file named `bangs.(json|yml|yaml|toml|hcl)` in the fo
   - `1` - Pass-through without escaping: `cat pictures` &rArr; `cat pictures`
   - `2` - Escapes with `url.PathEscape`: `cat pictures` &rArr; `cat%20pictures`
 - `format` `(string: <req>)` defines the template used to create the Bang's resulting query string. Use `{{{s}}}` to denote where the query should be substituted.
+
+Example YAML entry for GoDoc:
+
+```json
+godoc:
+  # try it: bang godoc github.com/travis-g/bang
+  description: GoDoc
+  escape_method: 1
+  format: "https://godoc.org/{{{s}}}"
+```
 
 See the [`bang.proto`](bang.proto) file for the Bang object format.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The system's URL opener will be used by default, but if set, the `BROWSER` envir
 
 The CLI looks for a config file named `bangs.(json|yml|yaml|toml|hcl)` in the following locations, in order:
 
-```
+```plain
 ~/.config/bang/
 ~/.config/
 ./ (current directory)

--- a/bang.pb.go
+++ b/bang.pb.go
@@ -20,12 +20,17 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+// EscapeMethod is the type of escaping to be used when escaping non-URL
+// safe characters, like spaces and quotes.
 type Bang_EscapeMethod int32
 
 const (
+	// Escapes the input with url.QueryEscape: "cat pictures" => "cat+pictures"
 	Bang_QUERY_ESCAPE Bang_EscapeMethod = 0
+	// Does no escaping: "cat pictures" => "cat pictures"
 	Bang_PASS_THROUGH Bang_EscapeMethod = 1
-	Bang_PATH_ESCAPE  Bang_EscapeMethod = 2
+	// Escapes the input with url.PathEscape: "cat pictures" => "cat%20pictures"
+	Bang_PATH_ESCAPE Bang_EscapeMethod = 2
 )
 
 var Bang_EscapeMethod_name = map[int32]string{
@@ -49,8 +54,12 @@ func (Bang_EscapeMethod) EnumDescriptor() ([]byte, []int) {
 }
 
 type Bang struct {
-	Name                 string            `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	Format               string            `protobuf:"bytes,2,opt,name=format,proto3" json:"format,omitempty"`
+	// Name of the Bang, which is used as its ID.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Format of the Bang, where '{{{s}}}' will be substituted with the escaped
+	// query string.
+	Format string `protobuf:"bytes,2,opt,name=format,proto3" json:"format,omitempty"`
+	// Description is a summary of the Bang.
 	Description          string            `protobuf:"bytes,3,opt,name=description,proto3" json:"description,omitempty"`
 	EscapeMethod         Bang_EscapeMethod `protobuf:"varint,4,opt,name=escape_method,json=escapeMethod,proto3,enum=main.Bang_EscapeMethod" json:"escape_method,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`

--- a/bang.proto
+++ b/bang.proto
@@ -2,13 +2,24 @@ syntax = "proto3";
 package main;
 
 message Bang {
+	// Name of the Bang, which is used as its ID.
 	string name = 1;
+
+	// Format of the Bang, where '{{{s}}}' will be substituted with the escaped
+	// query string.
 	string format = 2;
+
+	// Description is a summary of the Bang.
 	string description = 3;
 
+	// EscapeMethod is the type of escaping to be used when escaping non-URL
+	// safe characters, like spaces and quotes.
 	enum EscapeMethod {
+		// Escapes the input with url.QueryEscape: "cat pictures" => "cat+pictures"
 		QUERY_ESCAPE = 0;
+		// Does no escaping: "cat pictures" => "cat pictures"
 		PASS_THROUGH = 1;
+		// Escapes the input with url.PathEscape: "cat pictures" => "cat%20pictures"
 		PATH_ESCAPE = 2;
 	}
 	EscapeMethod escape_method = 4;

--- a/main.go
+++ b/main.go
@@ -21,35 +21,78 @@ var (
 	flagURLOnly *bool
 )
 
-func loadConfig() {
+var helpText = strings.TrimSpace(`
+bang - browser launcher, heavily inspired by DuckDuckGo's !bangs
+
+Usage:  bang [options] <bang> <query ...>
+        bang [options] <bang> -
+        bang [options] -
+        bang list
+        bang help
+
+Bangs can be configured with any filetype supported by viper
+(github.com/spf13/viper) but must be named "bangs", ex. "bangs.json". The CLI
+will look for a "bangs" config file in the following directories, in order:
+
+    ~/.config/bang/
+    ~/.config/
+    ./ ($PWD)
+
+See the source for an example "bangs.json" config file to get started.
+
+Queries can be piped through Stdin if a hyphen is passed as the bang or query
+argument. Depending on the location of the hyphen within the args list the full
+bang and query can be provided via Stdin.
+
+The system's URL opener will be used by default, but if set, the BROWSER
+environment variable will be executed with the chosen bang's URL passed as the
+final argument.
+
+Examples:
+
+  Search for cat pictures on Google Images:
+  bang gi cat pictures
+
+  Pipe a full query in via Stdin:
+  echo "gi cat pictures" | bang -
+
+  Pipe just a query, and output the URL only:
+  echo "cat pictures" | bang -url gi -
+
+Options:
+`)
+
+func loadConfig() error {
 	viper.SetConfigName("bangs")
 	viper.AddConfigPath("$HOME/.config/bang/")
 	viper.AddConfigPath("$HOME/.config/")
 	viper.AddConfigPath(".")
+
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("fatal error in config file: %s", err))
+		return err
 	}
 	// Unmarshal each key of config file as a proto.Message then stick it back
 	// into the global map of named Bangs
 	for key, i := range viper.AllSettings() {
 		jsonBytes, err := json.Marshal(i)
 		if err != nil {
-			panic(fmt.Errorf("fatal error in config file: %s", err))
+			return fmt.Errorf("fatal error in config file: %s", err)
 		}
 		buf := bytes.NewReader(jsonBytes)
 		var bang Bang
 		if jsonpb.Unmarshal(buf, &bang) != nil {
-			panic(fmt.Errorf("fatal error in config file: %s", err))
+			return fmt.Errorf("fatal error in config file: %s", err)
 		}
 		bang.Name = key
 		Bangs[key] = bang
 	}
+	return nil
 }
 
-func loadFlags(fs *flag.FlagSet) {
+func loadFlags(fs *flag.FlagSet) error {
 	flagURLOnly = fs.Bool("url", false, "output URL only")
-	fs.Parse(os.Args[1:])
+	return fs.Parse(os.Args[1:])
 }
 
 // TODO: make exported
@@ -72,13 +115,56 @@ func launch(url string) error {
 	return browser.OpenURL(url)
 }
 
+func stdinToString() (string, error) {
+	in, _ := os.Stdin.Stat()
+	interactive := ((in.Mode() & os.ModeCharDevice) != 0)
+	if !interactive {
+		bytes, err := ioutil.ReadAll(os.Stdin)
+		q := strings.TrimSpace(string(bytes))
+		return q, err
+	}
+	return "", fmt.Errorf("%s", "unable to read os.Stdin")
+}
+
 func main() {
 	fs = flag.NewFlagSet("bang", flag.ExitOnError)
-	loadConfig()
-	loadFlags(fs)
+	fs.Usage = func() {
+		fmt.Fprintf(os.Stderr, "%s\n", helpText)
+		fs.PrintDefaults()
+	}
+
+	err := loadConfig()
+	if err != nil {
+		switch err.(type) {
+		case viper.ConfigFileNotFoundError:
+			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		default:
+			panic(fmt.Errorf("error loading config: %s", err))
+		}
+	}
+
+	err = loadFlags(fs)
+	if err != nil {
+		panic(fmt.Errorf("error loading flags: %s", err))
+	}
+
+	var args = fs.Args()
+	if len(args) == 0 {
+		fs.Usage()
+		os.Exit(0)
+	}
 
 	// check for special subcommands
-	switch fs.Arg(0) {
+	switch args[0] {
+	case "-":
+		// pull os.Stdin
+		q, err := stdinToString()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+		args = strings.Split(q, " ")
 	case "list":
 		fmt.Println(listBangs(Bangs))
 		os.Exit(0)
@@ -88,25 +174,23 @@ func main() {
 	}
 
 	// check for bang but not enough args
-	if len(fs.Args()) < 2 {
+	if len(args) < 2 {
 		fmt.Fprintln(os.Stderr, "not enough args")
 		fs.Usage()
 		os.Exit(1)
 	}
 
 	// lookup bang
-	if bang, ok := Bangs[fs.Arg(0)]; ok {
+	if bang, ok := Bangs[args[0]]; ok {
 		var q string
-		if fs.Arg(1) == "-" {
-			// TODO: read from os.Stdin
-			in, _ := os.Stdin.Stat()
-			interactive := ((in.Mode() & os.ModeCharDevice) != 0)
-			if !interactive {
-				bytes, _ := ioutil.ReadAll(os.Stdin)
-				q = strings.TrimSpace(string(bytes))
+		if args[1] == "-" {
+			q, err = stdinToString()
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err.Error())
+				os.Exit(1)
 			}
 		} else {
-			q = strings.Join(fs.Args()[1:], " ")
+			q = strings.Join(args[1:], " ")
 		}
 		url := bang.URL(q)
 
@@ -121,7 +205,7 @@ func main() {
 			os.Exit(1)
 		}
 	} else {
-		fmt.Fprintln(os.Stderr, fs.Arg(0), "not a configured bang")
+		fmt.Fprintln(os.Stderr, args[0], "not a configured bang")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
- Adds documentation to the help command, fixing #5.
- Adds the ability to read both a bang and a query through stdin by passing `-` as the bang argument, similarly to how queries could be piped. Implements #7.